### PR TITLE
CI: diagnose macOS ctest failures (no fail-fast + output-on-failure)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+        fail-fast: false
         matrix:
             os: [ubuntu-latest, macos-latest]
     steps:
@@ -48,4 +49,4 @@ jobs:
       working-directory: ${{github.workspace}}/cpp/build
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: export STUDENT_NAME="name" STUDENT_GROUP="group" && ctest
+      run: export STUDENT_NAME="name" STUDENT_GROUP="group" && ctest --output-on-failure

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -49,4 +49,9 @@ jobs:
       working-directory: ${{github.workspace}}/cpp/build
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: export STUDENT_NAME="name" STUDENT_GROUP="group" && ctest --output-on-failure
+      run: |
+        export STUDENT_NAME="name" STUDENT_GROUP="group"
+        # macOS dyld does not search /usr/local/lib for bare dlopen names
+        # (Linux handles this via ldconfig); make the installed task libs findable.
+        export DYLD_LIBRARY_PATH="/usr/local/lib:$DYLD_LIBRARY_PATH"
+        ctest --output-on-failure


### PR DESCRIPTION
Diagnostic: let the ubuntu leg finish and print the real ctest error on macOS so the long-standing red CMake run can be root-caused.